### PR TITLE
Fix minor callout issue in README

### DIFF
--- a/Themes/LiquidGlass/README.md
+++ b/Themes/LiquidGlass/README.md
@@ -17,7 +17,8 @@
 
 ## Translucent Windows
 
-> [!NOTE] Make sure to change the "AccentBlurBehind color blend" setting to "cccccccc" if you are using this with Light themes.
+> [!NOTE]
+>  Make sure to change the "AccentBlurBehind color blend" setting to "cccccccc" if you are using this with Light themes.
 
 To import the mod settings, follow these steps:
 


### PR DESCRIPTION
Looks like this repo doesn't have full support for GitHub Markdown callouts. I've adjusted the Note callout to use a compatible callout format.

---

Normally with GitHub Markdwon Callouts you can swap the default callout header with the message by simply formatting it like so:

```md
> [!CALLOUT_TYPE] <YOUR_MESSEGE_HERE>
```

Normally I use this format due to it looking a lot cleaner. If this format had worked, it would look like this:

<img src="https://cdn.alekeagle.me/RKzpaxyMiM.png" width="100%" height="auto" />

But for some reason that format doesn't appear to work in this repo. So, I've reformatted it to the basic format like so:

```md
> [!CALLOUT_TYPE]
> <YOUR_MESSEGE_HERE>
```

With this format, it looks like this:

<img src="https://cdn.alekeagle.me/KHwCWIg8zl.png" width="100%" height="auto" />